### PR TITLE
v0.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2023-02-18
+
+Fix Elixir code based on warnings. Nothing will be changed at the high level.
+
+**Changed**
+
+- Use Application.compile_env/3 instead of Application.get_env/3
+- Define mocks at compile time instead of at runtime
+- Bump Elixir versions in CI
+
 ## [0.1.4] - 2021-11-26
 
 **Improvement**
@@ -51,7 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/mnishiguchi/sgp40/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/mnishiguchi/sgp40/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/mnishiguchi/sgp40/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/mnishiguchi/sgp40/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/mnishiguchi/sgp40/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/mnishiguchi/sgp40/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/mnishiguchi/sgp40/compare/v0.1.0...v0.1.1

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SGP40.MixProject do
   use Mix.Project
 
-  @version "0.1.4"
+  @version "0.1.5"
   @source_url "https://github.com/mnishiguchi/sgp40"
 
   def project do


### PR DESCRIPTION
Fix Elixir code based on warnings. Nothing will be changed at the high level.

**Changed**

- Use Application.compile_env/3 instead of Application.get_env/3
- Define mocks at compile time instead of at runtime
- Bump Elixir versions in CI